### PR TITLE
Avoid `Cannot read property 'icons' of undefined`

### DIFF
--- a/src/js/tempusdominus.js
+++ b/src/js/tempusdominus.js
@@ -670,7 +670,7 @@ const DateTimePicker = (($, moment) => {
         //noinspection JSMethodCanBeStatic
         _getOptions(options) {
             options = $.extend(true, {}, Default, (
-                options.icons && options.icons.type === 'feather' ?
+                options && options.icons && options.icons.type === 'feather' ?
                 {
                     icons: defaultFeatherIcons
                 }


### PR DESCRIPTION
The `options` property can be undefined here.